### PR TITLE
Fix decode_pair field length handling

### DIFF
--- a/dex.py
+++ b/dex.py
@@ -93,7 +93,12 @@ def decode_pair(data):
             str_len = data[pos]
             pos += 1
 
-            if str_len == 0 or str_len > 100 or pos + str_len > len(data):
+            # If the declared length looks unreasonable or extends past the
+            # available data, stop parsing this pair to avoid misalignment.
+            if str_len > 100 or pos + str_len > len(data):
+                break
+
+            if str_len == 0:
                 continue
 
             value = clean_string(data[pos:pos+str_len].decode('utf-8', errors='ignore'))


### PR DESCRIPTION
## Summary
- stop parsing a pair if the declared field length exceeds the buffer
- ignore empty fields without breaking pair parsing

## Testing
- `python -m py_compile dex.py`


------
https://chatgpt.com/codex/tasks/task_b_683c78a51cb48325a6111b31f49b27ea