### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,4 +146,4 @@ GPL-v3
 ## Disclaimer
 
 This is an unofficial client for DexScreener's WebSocket API. Use at your own risk and ensure compliance with DexScreener's terms of service.
-This is not affiliated with DexScreener in any-way.
+This is not affiliated with DexScreener in any way.


### PR DESCRIPTION
## Summary
- fix punctuation typo in README from `any-way` to `any way`

## Testing
- `python -m py_compile dex.py`


------
https://chatgpt.com/codex/tasks/task_b_683ca89ff8908325a71423c8e913a2ab